### PR TITLE
Disable flickr animation based on accessibility settings

### DIFF
--- a/src/effects/_crt.scss
+++ b/src/effects/_crt.scss
@@ -56,3 +56,9 @@ $screen-background: #121010;
     pointer-events: none;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .aesthetic-effect-crt::after {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
Love this effect and its elegant implementation, but worried about users with photosensitive seizures. This disables the animation for users who have turned on an accessibility feature requesting reduced motion. You can test in Firefox by adding setting `ui.prefersReducedMotion` (number) = 1 in about:config